### PR TITLE
docs: fix main executable filename in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ A production‑oriented Node.js scanner that hunts for **coins about to pump** o
 
 **Files**
 ```
-KucoinCoinFinderMaster.js   # Main executable
+KucoinCoinFinderUltra.js   # Main executable
 .env                        # Environment variables (thresholds, email, schedule)
 ```
 


### PR DESCRIPTION
## Summary
- fix main executable filename in README

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897cacb006c833098cd276e1fc85dd7